### PR TITLE
feat: play a sound feedback whenever a buff is received and lost

### DIFF
--- a/4RTools.csproj
+++ b/4RTools.csproj
@@ -325,6 +325,12 @@
       <DependentUpon>AutoBuffStatusForm.cs</DependentUpon>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </Compile>
+    <Compile Include="Forms\SoundBuffSkillForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Forms\SoundBuffSkillForm.Designer.cs">
+      <DependentUpon>SoundBuffSkillForm.cs</DependentUpon>
+    </Compile>
     <Compile Include="Forms\StuffAutoBuffForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -360,6 +366,9 @@
       <DependentUpon>AutoBuffStatusForm.cs</DependentUpon>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="Forms\SoundBuffSkillForm.resx">
+      <DependentUpon>SoundBuffSkillForm.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="Forms\StuffAutoBuffForm.resx">
       <DependentUpon>StuffAutoBuffForm.cs</DependentUpon>
     </EmbeddedResource>
@@ -380,6 +389,7 @@
     <Compile Include="Model\Custom.cs" />
     <Compile Include="Model\LocalServerManager.cs" />
     <Compile Include="Model\DebuffsRecovery.cs" />
+    <Compile Include="Model\SoundBuffRenderer.cs" />
     <Compile Include="Model\StatusRecovery.cs" />
     <!-- <Compile Include="Model\Tracker.cs" /> -->
     <Compile Include="Model\UserPreferences.cs" />

--- a/Forms/Container.Designer.cs
+++ b/Forms/Container.Designer.cs
@@ -33,6 +33,7 @@ namespace _4RTools.Forms
             System.Windows.Forms.TabControl atkDefMode;
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Container));
             this.tabPageSpammer = new System.Windows.Forms.TabPage();
+            this.tabPageSoundSkill = new System.Windows.Forms.TabPage();
             this.tabPageAutobuffSkill = new System.Windows.Forms.TabPage();
             this.tabPageAutobuffStuff = new System.Windows.Forms.TabPage();
             this.tabPageMacroSongs = new System.Windows.Forms.TabPage();
@@ -71,6 +72,7 @@ namespace _4RTools.Forms
             // atkDefMode
             // 
             atkDefMode.Controls.Add(this.tabPageSpammer);
+            atkDefMode.Controls.Add(this.tabPageSoundSkill);
             atkDefMode.Controls.Add(this.tabPageAutobuffSkill);
             atkDefMode.Controls.Add(this.tabPageAutobuffStuff);
             atkDefMode.Controls.Add(this.tabPageMacroSongs);
@@ -103,6 +105,16 @@ namespace _4RTools.Forms
             this.tabPageAutobuffSkill.Size = new System.Drawing.Size(629, 274);
             this.tabPageAutobuffSkill.TabIndex = 3;
             this.tabPageAutobuffSkill.Text = "Autobuff - Skills";
+            // 
+            // tabPageSoundSkill
+            // 
+            this.tabPageSoundSkill.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(45)))), ((int)(((byte)(49)))));
+            this.tabPageSoundSkill.Location = new System.Drawing.Point(4, 22);
+            this.tabPageSoundSkill.Name = "tabPageSoundSkill";
+            this.tabPageSoundSkill.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPageSoundSkill.Size = new System.Drawing.Size(629, 274);
+            this.tabPageSoundSkill.TabIndex = 3;
+            this.tabPageSoundSkill.Text = "Sound - Skills";
             // 
             // tabPageAutobuffStuff
             // 
@@ -441,6 +453,7 @@ namespace _4RTools.Forms
         private System.Windows.Forms.ComboBox processCB;
         private System.Windows.Forms.Button btnRefresh;
         private System.Windows.Forms.TabPage tabPageSpammer;
+        private System.Windows.Forms.TabPage tabPageSoundSkill;
         private System.Windows.Forms.LinkLabel lblLinkDiscord;
         private System.Windows.Forms.LinkLabel lblLinkGithub;
         private System.Windows.Forms.Panel panelDiscImage;

--- a/Forms/Container.cs
+++ b/Forms/Container.cs
@@ -36,6 +36,7 @@ namespace _4RTools.Forms
             SetAutoBuffStatusWindow();
             SetProfileWindow();
             SetAutobuffStuffWindow();
+            SetSoundBuffSkillWindow();
             SetAutobuffSkillWindow();
             SetSongMacroWindow();
             SetATKDEFWindow();
@@ -285,6 +286,16 @@ namespace _4RTools.Forms
             frm.MdiParent = this;
             frm.Show();
             addform(this.tabPageAutobuffStuff, frm);
+        }
+
+        public void SetSoundBuffSkillWindow()
+        {
+            SoundBuffSkillForm frm = new SoundBuffSkillForm(subject);
+            frm.FormBorderStyle = FormBorderStyle.None;
+            frm.Location = new Point(0, 65);
+            frm.MdiParent = this;
+            addform(this.tabPageSoundSkill, frm);
+            frm.Show();
         }
 
         public void SetAutobuffSkillWindow()

--- a/Forms/SoundBuffSkillForm.Designer.cs
+++ b/Forms/SoundBuffSkillForm.Designer.cs
@@ -1,0 +1,205 @@
+﻿namespace _4RTools.Forms
+{
+    partial class SoundBuffSkillForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SkillAutoBuffForm));
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.pictureBox38 = new System.Windows.Forms.PictureBox();
+            this.ArcherSkillsGP = new System.Windows.Forms.GroupBox();
+            this.SwordmanSkillGP = new System.Windows.Forms.GroupBox();
+            this.MageSkillGP = new System.Windows.Forms.GroupBox();
+            this.MerchantSkillsGP = new System.Windows.Forms.GroupBox();
+            this.ThiefSkillsGP = new System.Windows.Forms.GroupBox();
+            this.AcolyteSkillsGP = new System.Windows.Forms.GroupBox();
+            this.TKSkillGroupBox = new System.Windows.Forms.GroupBox();
+            this.NinjaSkillsGP = new System.Windows.Forms.GroupBox();
+            this.GunsSkillsGP = new System.Windows.Forms.GroupBox();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox38)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // pictureBox38
+            // 
+            this.pictureBox38.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("pictureBox38.BackgroundImage")));
+            this.pictureBox38.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            this.pictureBox38.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.pictureBox38.Location = new System.Drawing.Point(274, 290);
+            this.pictureBox38.Name = "pictureBox38";
+            this.pictureBox38.Size = new System.Drawing.Size(36, 26);
+            this.pictureBox38.TabIndex = 145;
+            this.pictureBox38.TabStop = false;
+            // 
+            // ArcherSkillsGP
+            // 
+            this.ArcherSkillsGP.AutoSize = true;
+            this.ArcherSkillsGP.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.ArcherSkillsGP.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(148)))), ((int)(((byte)(155)))), ((int)(((byte)(164)))));
+            this.ArcherSkillsGP.Location = new System.Drawing.Point(12, 12);
+            this.ArcherSkillsGP.Name = "ArcherSkillsGP";
+            this.ArcherSkillsGP.Size = new System.Drawing.Size(505, 30);
+            this.ArcherSkillsGP.TabIndex = 200;
+            this.ArcherSkillsGP.TabStop = false;
+            this.ArcherSkillsGP.Text = "Archer Skills";
+            // 
+            // SwordmanSkillGP
+            // 
+            this.SwordmanSkillGP.AutoSize = true;
+            this.SwordmanSkillGP.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.SwordmanSkillGP.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(148)))), ((int)(((byte)(155)))), ((int)(((byte)(164)))));
+            this.SwordmanSkillGP.Location = new System.Drawing.Point(12, 48);
+            this.SwordmanSkillGP.Name = "SwordmanSkillGP";
+            this.SwordmanSkillGP.Size = new System.Drawing.Size(505, 32);
+            this.SwordmanSkillGP.TabIndex = 201;
+            this.SwordmanSkillGP.TabStop = false;
+            this.SwordmanSkillGP.Text = "Swordsman Skills";
+            // 
+            // MageSkillGP
+            // 
+            this.MageSkillGP.AutoSize = true;
+            this.MageSkillGP.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.MageSkillGP.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(148)))), ((int)(((byte)(155)))), ((int)(((byte)(164)))));
+            this.MageSkillGP.Location = new System.Drawing.Point(12, 86);
+            this.MageSkillGP.Name = "MageSkillGP";
+            this.MageSkillGP.Size = new System.Drawing.Size(505, 35);
+            this.MageSkillGP.TabIndex = 202;
+            this.MageSkillGP.TabStop = false;
+            this.MageSkillGP.Text = "Mage Skills";
+            // 
+            // MerchantSkillsGP
+            // 
+            this.MerchantSkillsGP.AutoSize = true;
+            this.MerchantSkillsGP.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.MerchantSkillsGP.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(148)))), ((int)(((byte)(155)))), ((int)(((byte)(164)))));
+            this.MerchantSkillsGP.Location = new System.Drawing.Point(12, 127);
+            this.MerchantSkillsGP.Name = "MerchantSkillsGP";
+            this.MerchantSkillsGP.Size = new System.Drawing.Size(505, 35);
+            this.MerchantSkillsGP.TabIndex = 203;
+            this.MerchantSkillsGP.TabStop = false;
+            this.MerchantSkillsGP.Text = "Merchant Skills";
+            // 
+            // ThiefSkillsGP
+            // 
+            this.ThiefSkillsGP.AutoSize = true;
+            this.ThiefSkillsGP.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.ThiefSkillsGP.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(148)))), ((int)(((byte)(155)))), ((int)(((byte)(164)))));
+            this.ThiefSkillsGP.Location = new System.Drawing.Point(12, 168);
+            this.ThiefSkillsGP.Name = "ThiefSkillsGP";
+            this.ThiefSkillsGP.Size = new System.Drawing.Size(505, 35);
+            this.ThiefSkillsGP.TabIndex = 204;
+            this.ThiefSkillsGP.TabStop = false;
+            this.ThiefSkillsGP.Text = "Thief Skills";
+            // 
+            // AcolyteSkillsGP
+            // 
+            this.AcolyteSkillsGP.AutoSize = true;
+            this.AcolyteSkillsGP.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.AcolyteSkillsGP.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(148)))), ((int)(((byte)(155)))), ((int)(((byte)(164)))));
+            this.AcolyteSkillsGP.Location = new System.Drawing.Point(12, 213);
+            this.AcolyteSkillsGP.Name = "AcolyteSkillsGP";
+            this.AcolyteSkillsGP.Size = new System.Drawing.Size(505, 35);
+            this.AcolyteSkillsGP.TabIndex = 205;
+            this.AcolyteSkillsGP.TabStop = false;
+            this.AcolyteSkillsGP.Text = "Acolyte Skills";
+            // 
+            // TKSkillGroupBox
+            // 
+            this.TKSkillGroupBox.AutoSize = true;
+            this.TKSkillGroupBox.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.TKSkillGroupBox.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(148)))), ((int)(((byte)(155)))), ((int)(((byte)(164)))));
+            this.TKSkillGroupBox.Location = new System.Drawing.Point(12, 254);
+            this.TKSkillGroupBox.Name = "TKSkillGroupBox";
+            this.TKSkillGroupBox.Size = new System.Drawing.Size(505, 35);
+            this.TKSkillGroupBox.TabIndex = 206;
+            this.TKSkillGroupBox.TabStop = false;
+            this.TKSkillGroupBox.Text = "Taekwon Skills";
+            // 
+            // NinjaSkillsGP
+            // 
+            this.NinjaSkillsGP.AutoSize = true;
+            this.NinjaSkillsGP.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.NinjaSkillsGP.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(148)))), ((int)(((byte)(155)))), ((int)(((byte)(164)))));
+            this.NinjaSkillsGP.Location = new System.Drawing.Point(12, 295);
+            this.NinjaSkillsGP.Name = "NinjaSkillsGP";
+            this.NinjaSkillsGP.Size = new System.Drawing.Size(505, 35);
+            this.NinjaSkillsGP.TabIndex = 207;
+            this.NinjaSkillsGP.TabStop = false;
+            this.NinjaSkillsGP.Text = "Ninja Skills";
+            // 
+            // GunsSkillsGP
+            // 
+            this.GunsSkillsGP.AutoSize = true;
+            this.GunsSkillsGP.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.GunsSkillsGP.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(148)))), ((int)(((byte)(155)))), ((int)(((byte)(164)))));
+            this.GunsSkillsGP.Location = new System.Drawing.Point(12, 336);
+            this.GunsSkillsGP.Name = "GunsSkillsGP";
+            this.GunsSkillsGP.Size = new System.Drawing.Size(505, 35);
+            this.GunsSkillsGP.TabIndex = 208;
+            this.GunsSkillsGP.TabStop = false;
+            this.GunsSkillsGP.Text = "Gunslinger Skills";
+            // 
+            // SkillAutoBuffForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScroll = true;
+            this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(43)))), ((int)(((byte)(45)))), ((int)(((byte)(49)))));
+            this.ClientSize = new System.Drawing.Size(563, 388);
+            this.Controls.Add(this.GunsSkillsGP);
+            this.Controls.Add(this.NinjaSkillsGP);
+            this.Controls.Add(this.TKSkillGroupBox);
+            this.Controls.Add(this.AcolyteSkillsGP);
+            this.Controls.Add(this.ThiefSkillsGP);
+            this.Controls.Add(this.MerchantSkillsGP);
+            this.Controls.Add(this.MageSkillGP);
+            this.Controls.Add(this.ArcherSkillsGP);
+            this.Controls.Add(this.SwordmanSkillGP);
+            this.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(148)))), ((int)(((byte)(155)))), ((int)(((byte)(164)))));
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            this.Name = "SkillAutoBuffForm";
+            this.Text = "SkilAutoBuffForm";
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBox38)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+        private System.Windows.Forms.ToolTip toolTip1;
+        private System.Windows.Forms.PictureBox pictureBox38;
+        private System.Windows.Forms.GroupBox ArcherSkillsGP;
+        private System.Windows.Forms.GroupBox SwordmanSkillGP;
+        private System.Windows.Forms.GroupBox MageSkillGP;
+        private System.Windows.Forms.GroupBox MerchantSkillsGP;
+        private System.Windows.Forms.GroupBox ThiefSkillsGP;
+        private System.Windows.Forms.GroupBox AcolyteSkillsGP;
+        private System.Windows.Forms.GroupBox TKSkillGroupBox;
+        private System.Windows.Forms.GroupBox NinjaSkillsGP;
+        private System.Windows.Forms.GroupBox GunsSkillsGP;
+    }
+}

--- a/Forms/SoundBuffSkillForm.cs
+++ b/Forms/SoundBuffSkillForm.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Windows.Forms;
+using _4RTools.Utils;
+using _4RTools.Model;
+using System.Windows.Input;
+using System.Collections.Generic;
+
+namespace _4RTools.Forms
+{
+    public partial class SoundBuffSkillForm : Form, IObserver
+    {
+
+        private List<BuffContainer> skillContainers =  new List<BuffContainer>();
+
+        public SoundBuffSkillForm(Subject subject)
+        {
+            this.KeyPreview = true;
+            InitializeComponent();
+
+            skillContainers.Add(new BuffContainer(this.ArcherSkillsGP, Buff.GetArcherSkills()));
+            skillContainers.Add(new BuffContainer(this.SwordmanSkillGP, Buff.GetSwordmanSkill()));
+            skillContainers.Add(new BuffContainer(this.MageSkillGP, Buff.GetMageSkills()));
+            skillContainers.Add(new BuffContainer(this.MerchantSkillsGP, Buff.GetMerchantSkills()));
+            skillContainers.Add(new BuffContainer(this.ThiefSkillsGP, Buff.GetThiefSkills()));
+            skillContainers.Add(new BuffContainer(this.AcolyteSkillsGP, Buff.GetAcolyteSkills()));
+            skillContainers.Add(new BuffContainer(this.TKSkillGroupBox, Buff.GetTaekwonSkills()));
+            skillContainers.Add(new BuffContainer(this.NinjaSkillsGP, Buff.GetNinjaSkills()));
+            skillContainers.Add(new BuffContainer(this.GunsSkillsGP, Buff.GetGunsSkills()));
+
+            new SoundBuffRenderer(skillContainers, toolTip1).doRender();
+            subject.Attach(this);
+
+        }
+
+        public void Update(ISubject subject)
+        {
+            switch ((subject as Subject).Message.code)
+            {
+                case MessageCode.PROFILE_CHANGED:
+                    SoundBuffRenderer.doUpdate(new Dictionary<EffectStatusIDs, Key>(ProfileSingleton.GetCurrent().Autobuff.buffMapping), this);
+                    break;
+            }
+        }
+    }
+}

--- a/Forms/SoundBuffSkillForm.resx
+++ b/Forms/SoundBuffSkillForm.resx
@@ -1,0 +1,148 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="pictureBox38.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        R0lGODlhGAAYAIcSAP8A/71kVZxNSKSSdYV2Y1RkOv+0c3Y6MuHNnLvBizJFH///wE8mHJmicHaDVf/p
+        rsKwiQ8lBAAAAE4sRt3gpmEAAI8iGO1kR75DMPelcvKFWWNZUN6MZG8AaQBuAF8AcwBhAGQAbgBfAHQA
+        TwBoAHIAZQBzADAALQA2ADAALQA4ADIALQAwADYAMABcAGsAUwBpAGwAbABfAGUAUgBsAHQAYQBlAFwA
+        ZABzAGkAawBsAF8AbABpAG8AYwBuAFwAcwBzAGkAawBsAF8AbABpAG8AYwBuAGcAXwBpAFwAZgBuAF8A
+        agBuAG4AZQAuAGkAZwBmAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAACDB2NrYABwAEnf1HQAARMQAAAAAIAAVACDB2AAAAKwAAAAS2/Ud
+        yQF4d8gAFXf1HhUGCBZqAAB39QAAAPUVawAAdwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+        AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF4AOAAFQAgwRbdON1AAHgAFgAVAQAAAAAAANwAAAAS3BLc
+        pADyANgA9AAgwQAAAAAAAAAAAAAAABLY+FOEAHQCagAS3AAAiQIoAP8AAP////U5ujoXd2p39QABWRUA
+        ANrwAIAAEsAQABLcdJAFAMh393f21f///xZq/wB39QAAAPUVa7KbdwB35wAAAAD//6WAAIACZwJnpQAA
+        GAAAAAwAAAAS3AAAQAAAAPAAAAAS2wAAAAAAAAAAAAAAAAAADAACAAEAAHf1Af3sAADyfwAAAAAAAAAA
+        AgD6AOACGgAgwQAAAMHgAAUAIAAAAOezvtxId6MAEnfntPdkW/DOd+h35wAAARLcbNx0AAgAEgAAAAAA
+        DiH/C05FVFNDQVBFMi4wAwEBAAAh+QQBAAAAACwAAAAAGAAYAAAI/wABAAggQIDAgwgTChxAgACAAgEM
+        HCggsOGAiwoBDECAgECBBAcCHEiggMBGjggwLty4YIHHBQcYMGiggGXLlikvIrjpUoGCBA4cFFCA4AHO
+        mztbQkg6IIIDBQUKRJBQdOeEnQgmQFiQ9eqCpgUoSI1QoegErgsgTPCqtu0ACxcaOCBb9sHVtRy3duX4
+        Fe4FDBYq1O26lSdXphYy/A1soSjXqxguIMXbN4Nixo7RSm4ZWa3Wt5YvWBitNunNszi9gr5sAYNZ0xMy
+        oEbbVwNrDJ6vbj4rGatLC7ZFty5qF0Lkm67vQiAA9zJgjg9M8/RclHlkwM8nRKd9/PGCB9YxAFq2EIHv
+        Xd9L0YK34ABDBfIRuFJ/vBcngQgFHEiIEEEB1wfUXZXVgAwB4FMB+ykQQXQXsZQUBAw6JFB/Eii4gUkV
+        mYRSSg0ldAAHDGQEgEUMSZiQADGJqKJAAQEAOw==
+</value>
+  </data>
+</root>

--- a/Model/Autobuff.cs
+++ b/Model/Autobuff.cs
@@ -5,6 +5,7 @@ using System.Windows.Forms;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using _4RTools.Utils;
+using System.Media;
 
 namespace _4RTools.Model
 {
@@ -16,6 +17,10 @@ namespace _4RTools.Model
         private _4RThread thread;
         public int delay { get; set; } = 1;
         public Dictionary<EffectStatusIDs, Key> buffMapping = new Dictionary<EffectStatusIDs, Key>();
+
+        private List<EffectStatusIDs> buffsFinishedAlreadyPlayed = new List<EffectStatusIDs>() { };
+        private List<EffectStatusIDs> buffsToWatch = new List<EffectStatusIDs>();
+
 
         public void Start()
         {
@@ -65,6 +70,11 @@ namespace _4RTools.Model
 
                     if (buffMapping.ContainsKey(status)) //CHECK IF STATUS EXISTS IN STATUS LIST AND DO ACTION
                     {
+                        if (buffsFinishedAlreadyPlayed.Contains(status))
+                        {
+                            buffsFinishedAlreadyPlayed.Remove(status);
+                            new SoundPlayer(Resources._4RTools.ETCResource.Speech_On).Play();
+                        }
                         bmClone.Remove(status);
                     }
 
@@ -74,6 +84,12 @@ namespace _4RTools.Model
                 buffs.Clear();
                 foreach (var item in bmClone)
                 {
+                    if (buffsToWatch.Contains(item.Key) && !buffsFinishedAlreadyPlayed.Contains(item.Key))
+                    {
+                        buffsFinishedAlreadyPlayed.Add(item.Key);
+                        new SoundPlayer(Resources._4RTools.ETCResource.Speech_Off).Play();
+                    }
+
                     if (foundQuag && (item.Key == EffectStatusIDs.CONCENTRATION || item.Key == EffectStatusIDs.INC_AGI || item.Key == EffectStatusIDs.TRUESIGHT || item.Key == EffectStatusIDs.ADRENALINE || item.Key == EffectStatusIDs.SPEARQUICKEN || item.Key == EffectStatusIDs.WINDWALK))
                     {
                         break;
@@ -108,6 +124,18 @@ namespace _4RTools.Model
                 buffMapping.Add(status, key);
             }
         }
+
+        public void AddStatusToSoundBuff(EffectStatusIDs status)
+        {
+            if (buffsToWatch.Contains(status))
+            {
+                buffsToWatch.Remove(status);
+                return;
+            }
+
+            buffsToWatch.Add(status);
+        }
+
         public void ClearKeyMapping()
         {
             buffMapping.Clear();

--- a/Model/SoundBuffRenderer.cs
+++ b/Model/SoundBuffRenderer.cs
@@ -1,0 +1,106 @@
+﻿using _4RTools.Utils;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using System.Windows.Input;
+
+namespace _4RTools.Model
+{
+    internal class SoundBuffRenderer
+    {
+
+        private readonly int BUFFS_PER_ROW = 5;
+        private readonly int DISTANCE_BETWEEN_CONTAINERS = 10;
+        private readonly int DISTANCE_BETWEEN_ROWS = 30;
+
+        private List<BuffContainer> _containers;
+        private ToolTip _toolTip;
+
+        public SoundBuffRenderer(List<BuffContainer> containers, ToolTip toolTip)
+        {
+            this._containers = containers;
+            this._toolTip = toolTip;
+        }
+
+        public void doRender()
+        {
+            for (int i = 0; i < _containers.Count; i++)
+            {
+                BuffContainer bk = _containers[i];
+                Point lastLocation = new Point(bk.container.Location.X, 20);
+                int colCount = 0;
+
+                if (i > 0)
+                {
+                    //If not first container to be rendered, get last container height and append 70
+                    bk.container.Location = new Point(_containers[i - 1].container.Location.X, _containers[i - 1].container.Location.Y + _containers[i - 1].container.Height + DISTANCE_BETWEEN_CONTAINERS);
+                }
+
+                foreach (Buff skill in bk.skills)
+                {
+                    PictureBox pb = new PictureBox();
+                    CheckBox checkBox = new CheckBox();
+
+                    pb.Image = skill.icon;
+                    pb.BackgroundImageLayout = ImageLayout.Center;
+                    pb.Location = new Point(lastLocation.X + (colCount * 100), lastLocation.Y);
+                    pb.Name = "pbox" + ((int)skill.effectStatusID);
+                    pb.Size = new Size(26, 26);
+                    _toolTip.SetToolTip(pb, skill.name);
+
+                    checkBox.CheckStateChanged += onCheckChange;
+                    checkBox.Tag = ((int)skill.effectStatusID);
+                    checkBox.Location = new Point(pb.Location.X + 35, pb.Location.Y + 3);
+                    checkBox.Size = new Size(55, 20);
+                    checkBox.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(49)))), ((int)(((byte)(51)))), ((int)(((byte)(56)))));
+                    checkBox.ForeColor = System.Drawing.Color.White;
+
+                    bk.container.Controls.Add(checkBox);
+                    bk.container.Controls.Add(pb);
+
+                    colCount++;
+
+                    if (colCount == BUFFS_PER_ROW)
+                    {
+                        //5 Buffs per row
+                        colCount = 0;
+                        lastLocation = new Point(bk.container.Location.X, lastLocation.Y + DISTANCE_BETWEEN_ROWS);
+                    }
+                }
+            }
+        }
+
+        private void onCheckChange(object sender, EventArgs e)
+        {
+            try
+            {
+                CheckBox checkbox = (CheckBox)sender;
+
+                Key key = (Key)Enum.Parse(typeof(Key), checkbox.Tag.ToString());
+                EffectStatusIDs statusID = (EffectStatusIDs)Int16.Parse(checkbox.Tag.ToString());
+                ProfileSingleton.GetCurrent().Autobuff.AddStatusToSoundBuff(statusID);
+
+                //ProfileSingleton.SetConfiguration(ProfileSingleton.GetCurrent().Autobuff);
+            }
+            catch { }
+        }
+
+        public static void doUpdate(Dictionary<EffectStatusIDs, Key> autobuffDict, Control control)
+        {
+            FormUtils.ResetForm(control);
+            foreach (EffectStatusIDs effect in autobuffDict.Keys)
+            {
+                Control[] c = control.Controls.Find("in" + (int)effect, true);
+                if (c.Length > 0)
+                {
+                    CheckBox textBox = (CheckBox)c[0];
+                    textBox.Text = autobuffDict[effect].ToString();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
#30 This PR address this issue

This pull request introduces changes to the `4RTools` project, specifically adding a new feature for sound buff skills. The changes include the addition of new files, modification of existing files, and the introduction of a new form for sound buff skills.

I am reusing the buffs list from the autobuff, but now it has checkboxes. It is a proof of concept, it needs to be polished.

![image](https://github.com/biancaazuma/4RTools-RagTools/assets/1952333/a1870865-736e-4707-8245-7c9c62d64ec5)

## Future work

If this idea is accepted, we can think about changing the sound to be played. For now, the sound might be confusing, since I am reusing the ON/OFF existing sound.

Another change can be the 3 state check box:
Unchecked - off
Checked - plays sounds when receiving and losing the buff
Intermediate - plays sound only when the buff is lost

## Key changes include:

New feature addition:
* [`Forms/SoundBuffSkillForm.Designer.cs`](diffhunk://#diff-0e21d15bda10303abfc06772703251b0234c7e981e596d09b9e701aa1afd1087R1-R205): A new form `SoundBuffSkillForm` has been created. This form contains various skill group boxes for different character types.
* [`Forms/SoundBuffSkillForm.cs`](diffhunk://#diff-ed5d3f542a9bf7ef189a5e0f3ed3a6c78f9dfcf7bb7f9284a1814278ff407ca2R1-R45): The implementation of `SoundBuffSkillForm` has been added. It includes the rendering of sound buff skills and updates when the profile changes.

Modifications to existing files:
* [`4RTools.csproj`](diffhunk://#diff-39a363791cbab754ce35aeb98dcb2a9956db650873b4f961a3465875948f7049R328-R333): Added new files `SoundBuffSkillForm.cs`, `SoundBuffSkillForm.Designer.cs`, and `SoundBuffRenderer.cs` to the project. [[1]](diffhunk://#diff-39a363791cbab754ce35aeb98dcb2a9956db650873b4f961a3465875948f7049R328-R333) [[2]](diffhunk://#diff-39a363791cbab754ce35aeb98dcb2a9956db650873b4f961a3465875948f7049R369-R371) [[3]](diffhunk://#diff-39a363791cbab754ce35aeb98dcb2a9956db650873b4f961a3465875948f7049R392)
* [`Forms/Container.Designer.cs`](diffhunk://#diff-585ac8396c63b0ff809ee92ec3633a86e679bf8128acd8ee504829894db24182R36): Added a new tab `tabPageSoundSkill` to the `atkDefMode` control. [[1]](diffhunk://#diff-585ac8396c63b0ff809ee92ec3633a86e679bf8128acd8ee504829894db24182R36) [[2]](diffhunk://#diff-585ac8396c63b0ff809ee92ec3633a86e679bf8128acd8ee504829894db24182R75) [[3]](diffhunk://#diff-585ac8396c63b0ff809ee92ec3633a86e679bf8128acd8ee504829894db24182R109-R118) [[4]](diffhunk://#diff-585ac8396c63b0ff809ee92ec3633a86e679bf8128acd8ee504829894db24182R456)
* [`Forms/Container.cs`](diffhunk://#diff-a823c4f7ed5a8996f6dcde3527590d0137a49340930b75fd6de4a0c32d95a029R39): Added a call to `SetSoundBuffSkillWindow()` in the `Container()` constructor and implemented the `SetSoundBuffSkillWindow()` method to set up the new `SoundBuffSkillForm`. [[1]](diffhunk://#diff-a823c4f7ed5a8996f6dcde3527590d0137a49340930b75fd6de4a0c32d95a029R39) [[2]](diffhunk://#diff-a823c4f7ed5a8996f6dcde3527590d0137a49340930b75fd6de4a0c32d95a029R291-R300)